### PR TITLE
Fix mobile side nav menu

### DIFF
--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -1,2 +1,9 @@
 <script type="text/javascript" src="{{ site.baseurl }}/bower_components/jquery/dist/jquery.min.js"></script>
 <script type="text/javascript" src="{{ site.baseurl }}/bower_components/materialize/dist/js/materialize.min.js"></script>
+
+<!-- Activates mobile side nav -->
+<script type="text/javascript">
+	$(document).ready(function() {
+		$(".button-collapse").sideNav();
+	});
+</script>


### PR DESCRIPTION
Prior to this fix the side menu could not be viewed when the user clicked on the hamburger menu
because the sidenav was not activated with jQuery.