### PR TITLE
Fix funky button behaviour & typo

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -31,3 +31,8 @@ ul.bullet-list > li {
 .content > ul > li > ul > li {
 	list-style-type: circle;
 }
+
+/* Fixes weird behaviour of buttons below a device width of 625px (WARNING: kind of hacky) */
+@media only screen and (max-width: 625px) {
+	.btn { display: block !important; }
+}

--- a/support/index.markdown
+++ b/support/index.markdown
@@ -45,7 +45,7 @@ Then, finally, we'll release ISOs to install the operating system in a VM or on 
 
 Our goal is not to be a pure free-software distro; if you want that, install our apps, shell, and
 login screen on another distro. Our goal is to be the best possible operating system for the typical
-computing user. So, if that means supporting proprietary software such as firmware and drivers, than
+computing user. So, if that means supporting proprietary software such as firmware and drivers, then
 we will support non-free software. And that includes supporting an appstore that supports selling
 proprietary software (if we ever get to that point).
 


### PR DESCRIPTION
On a device-width <= 625px buttons started laying out in a funky way.
Second commit fixes a typo on the FAQ
Fixes #33 & #30