### PR TITLE
change active class in mobile nav from `a` to `li`

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -30,7 +30,7 @@
       <ul id="nav-mobile" class="side-nav">
         {% for page in site.pages %}
           {% if page.title %}
-          <li><a class="page-link{% if page.url == current_url %} active{% endif %}"
+          <li{% if page.url == current_url %} class="active"{% endif %}><a class="page-link"
                  href="{{ page.url | prepend: site.baseurl }}">
               {% if page.short_title %}
                 {{ page.short_title }}


### PR DESCRIPTION
change active class in mobile nav from `a` to `li`
